### PR TITLE
update explanations/documentation links, rename practical notebook

### DIFF
--- a/Week5/RasterStats.ipynb
+++ b/Week5/RasterStats.ipynb
@@ -5,13 +5,13 @@
    "id": "latest-anime",
    "metadata": {},
    "source": [
-    "# EGM722 - Week 5 Practical: Vector and raster operations using python\n",
+    "# zonal statistics using rasterstats\n",
     "\n",
-    "## Overview\n",
+    "## overview\n",
     "\n",
     "Up to now, we have worked with either vector data or raster data, but we haven't really used them together. In this week's practical, we'll learn how we can combine these two data types, and see some examples of different analyses, such as zonal statistics or sampling raster data, that we can automate using python.\n",
     "\n",
-    "## Objectives\n",
+    "## objectives\n",
     "-  learn how to use `rasterstats` to perform zonal statistics\n",
     "-  use the `zip` built-in to combine iterables such as lists\n",
     "-  learn how to handle exceptions using `try` ... `except` blocks\n",
@@ -19,14 +19,14 @@
     "-  learn how to mask and select (index) rasters using vector data\n",
     "-  see additional plotting examples using `matplotlib`\n",
     "\n",
-    "## Data provided\n",
+    "## data provided\n",
     "\n",
     "In the data\\_files folder, you should have the following:\n",
     "-  LCM2015_Aggregate_100m.tif\n",
     "-  NI_DEM.tif\n",
     "\n",
     "\n",
-    "## 1. Getting started\n",
+    "## getting started\n",
     "\n",
     "In this practical, we'll look at a number of different GIS tasks related to working with both raster and vector data in python, as well as a few different python and programming concepts. To get started, run the cell below."
    ]
@@ -45,9 +45,7 @@
     "import pandas as pd\n",
     "import geopandas as gpd\n",
     "import matplotlib.pyplot as plt\n",
-    "import rasterstats\n",
-    "\n",
-    "plt.rcParams.update({'font.size': 22}) # update the font size for our plots to be size 22"
+    "import rasterstatsS"
    ]
   },
   {
@@ -55,12 +53,12 @@
    "id": "fifty-water",
    "metadata": {},
    "source": [
-    "## 2. Zonal statistics\n",
+    "## zonal statistics\n",
     "In GIS, [_zonal statistics_](https://pro.arcgis.com/en/pro-app/latest/tool-reference/spatial-analyst/how-zonal-statistics-works.htm) is a process whereby you calculate statistics for the pixels of a raster in different groups, or zones, defined by properties in another dataset. In this example, we're going to use the Northern Ireland County border dataset from Week 2, along with a re-classified version of the Northern Ireland [Land Cover Map](https://catalogue.ceh.ac.uk/documents/47f053a0-e34f-4534-a843-76f0a0998a2f) 2015[<sup id=\"fn1-back\">1</sup>](#fn1 \"footnote 1\").\n",
     "\n",
     "The Land Cover Map tells, for each pixel, what type of land cover is associated with a location - that is, whether it's woodland (and what kind of woodland), grassland, urban or built-up areas, and so on. For our re-classified version of the dataset, we're working with the aggregate class data, re-sampled to 100m resolution from the original 25m resolution.\n",
     "\n",
-    "The raster data type is _unsigned integer_ with a _bitdepth_ of 8 bits - that is, it has a range of possible values from 0 to 255. Even though it has this range of possible values, we only use 10 (11) of them:\n",
+    "The raster data type is *unsigned integer* with a *bitdepth* of 8 bits - that is, it has a range of possible values from 0 to 255. Even though it has this range of possible values, we only use 10 (11) of them:\n",
     "\n",
     "| Raster value | Aggregate class name       |\n",
     "| :------------|:---------------------------|\n",
@@ -76,7 +74,29 @@
     "| 9            | Coastal                    |\n",
     "| 10           | Built-up areas and gardens |\n",
     "\n",
-    "In the cell below, we'll create a __dict__ object of __key__/__value__ pairs that maps each raster value (the __key__) to a class name (the __value__):"
+    "In the cell below, we'll first define a **list** of landcover class names, in the order shown in the table above. Then, we'll use `range()` to create a list of values from 1 to 10, corresponding to the raster value of each landcover class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5fa9a5d-fb98-45ac-854c-eabbbb171cae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define the landcover class names in a list\n",
+    "names = ['Broadleaf woodland', 'Coniferous woodland', 'Arable', 'Improved grassland', 'Semi-natural grassland', \n",
+    "         'Mountain, heath, bog', 'Saltwater', 'Freshwater', 'Coastal', 'Built-up areas and gardens']\n",
+    "\n",
+    "values = range(1, 11) # get numbers from 1-10, corresponding to the landcover values"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7badea32-84fa-413b-bd3d-899c6e3ba7e2",
+   "metadata": {},
+   "source": [
+    "Next, we'll use a combination of the `zip()` built-in function ([documentation](https://docs.python.org/3/library/functions.html#zip)), along with `dict()` ([documentation](https://docs.python.org/3/library/functions.html#func-dict)), to create a **dict** object of **key**/**value** pairs that maps each raster value (the **key**) to a class name (the **value**):"
    ]
   },
   {
@@ -86,16 +106,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "landcover_names = {1: 'Broadleaf woodland',\n",
-    "                   2: 'Coniferous woodland',\n",
-    "                   3: 'Arable',\n",
-    "                   4: 'Improved grassland',\n",
-    "                   5: 'Semi-natural grassland',\n",
-    "                   6: 'Mountain, heath, bog',\n",
-    "                   7: 'Saltwater',\n",
-    "                   8: 'Freshwater',\n",
-    "                   9: 'Coastal',\n",
-    "                   10: 'Built-up areas and gardens'}"
+    "landcover_names = dict(zip(values, names)) # create a dict of landcover value/name pairs"
    ]
   },
   {
@@ -130,47 +141,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "living-immune",
+   "id": "947dd69e-a98c-4de1-932a-7e9616f7c570",
    "metadata": {},
    "source": [
-    "Next, we'll define a function that takes an array, and returns a __dict__ object containing the count (number of pixels) for each of the unique values in the array:\n",
-    "\n",
-    "```python\n",
-    "def count_unique(array, names, nodata=0):\n",
-    "    '''\n",
-    "    Count the unique elements of an array.\n",
-    "\n",
-    "    :param array: Input array\n",
-    "    :param names: a dict of key/value pairs that map raster values to a name\n",
-    "    :param nodata: nodata value to ignore in the counting\n",
-    "    \n",
-    "    :returns count_dict: a dictionary of unique values and counts\n",
-    "    '''\n",
-    "    count_dict = dict() # create the output dict\n",
-    "    for val in np.unique(array): # iterate over the unique values for the raster\n",
-    "        if val == nodata: # if the value is equal to our nodata value, move on to the next one\n",
-    "            continue\n",
-    "        count_dict[names[val]] = np.count_nonzero(array == val)\n",
-    "    return count_dict # return the now-populated output dict\n",
-    "```\n",
-    "\n",
-    "Here, we have three input parameters: the first, `array`, is our array (or raster data). The next, `names`, is a dict of __key__/__value__ pairs to provide human-readable names for each raster value. Finally, `nodata` is the value of the array that we should ignore. \n",
-    "\n",
-    "The first line of the function defines an empty __dict__ (`count_dict = dict()`), into which we'll place the __key__/__value__ pairs corresponding to the count for each landcover class.\n",
-    "\n",
-    "Next, using [`numpy.unique()`](https://numpy.org/doc/stable/reference/generated/numpy.unique.html), we get an array containing the unique values of the input array. \n",
-    "\n",
-    "Note that this works for data like this raster, where we have a limited number of pre-defined values. For something like a digital elevation model, which represents continuous floating-point values, we wouldn't want to use this approach to bin the data - we'll see how we can handle continuous data later on.\n",
-    "\n",
-    "For each of the different unique values `val`, we find all of the locations in `array` that have that value (`array == val`). Note that this is actually a boolean array, with values of either `True` where `array == val`, and `False` where `array != val`. [`numpy.count_nonzero()`](https://numpy.org/doc/stable/reference/generated/numpy.count_nonzero.html) the counts the number of non-zero (in this case, `True`) values in the array - that is, this:\n",
-    "\n",
-    "```python\n",
-    "np.count_nonzero(array == val)\n",
-    "```\n",
-    "\n",
-    "tells us the number of pixels in `array` that are equal to `val`. We then assign this to our dictionary with a key that is a __str__ representation of the value, before returning our `count_dict` variable at the end of the function.\n",
-    "\n",
-    "Run the cell below to define the function and run it on our `landcover` raster."
+    "Next, we'll define a function that takes an array, and returns a **dict** object containing the count (number of pixels) for each of the unique values in the array:"
    ]
   },
   {
@@ -195,8 +169,46 @@
     "        if val == nodata: # if the value is equal to our nodata value, move on to the next one\n",
     "            continue\n",
     "        count_dict[names[val]] = np.count_nonzero(array == val)\n",
-    "    return count_dict # return the now-populated output dict\n",
+    "    return count_dict # return the now-populated output dict"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "living-immune",
+   "metadata": {},
+   "source": [
+    "Here, we have three input parameters: the first, `array`, is our array (or raster data). The next, `names`, is a dict of **key**/**value** pairs to provide human-readable names for each raster value. Finally, `nodata` is the value of the input array that we should ignore. \n",
     "\n",
+    "The first line of the function defines an empty **dict**:\n",
+    "\n",
+    "```python\n",
+    "count_dict = dict()\n",
+    "```\n",
+    "\n",
+    "This is the empty container into which we'll place the **key**/**value** pairs corresponding to the count for each landcover class.\n",
+    "\n",
+    "Next, using `numpy.unique()` ([documentation](https://numpy.org/doc/stable/reference/generated/numpy.unique.html)), we get an array containing the unique values of the input array. \n",
+    "\n",
+    "Note that this works for data like this raster, where we have a limited number of pre-defined values. For something like a digital elevation model, which represents continuous floating-point values, we wouldn't want to use this approach to bin the data - we'll see how we can handle continuous data later on.\n",
+    "\n",
+    "For each of the different unique values `val`, we find all of the locations in `array` that have that value (`array == val`). Note that this is actually a boolean array, with values of either `True` where `array == val`, and `False` where `array != val`. `numpy.count_nonzero()` ([documentation](https://numpy.org/doc/stable/reference/generated/numpy.count_nonzero.html)) then counts the number of non-zero (in this case, `True`) values in the array - that is, this:\n",
+    "\n",
+    "```python\n",
+    "np.count_nonzero(array == val)\n",
+    "```\n",
+    "\n",
+    "tells us the number of pixels in `array` that are equal to `val`. We then assign this to our dictionary with a key that is a __str__ representation of the value, before returning our `count_dict` variable at the end of the function.\n",
+    "\n",
+    "Run the cell below to run the function on our `landcover` raster:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "65931094-8f0a-43d3-84a7-1b42fce091b6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "landcover_count = count_unique(landcover, landcover_names)\n",
     "print(landcover_count) # show the results"
    ]
@@ -229,7 +241,7 @@
    "id": "classical-dayton",
    "metadata": {},
    "source": [
-    "Now, let's have a look at the help for [`rasterstats.gen_zonal_stats()`](https://pythonhosted.org/rasterstats/rasterstats.html#rasterstats.gen_zonal_stats), which will tell us how we can use `rasterstats` to get zonal statistics for a raster and vector geometry:"
+    "Now, let's have a look at the help for `rasterstats.gen_zonal_stats()` ([documentation](https://pythonhosted.org/rasterstats/rasterstats.html#rasterstats.gen_zonal_stats)), which will tell us how we can use `rasterstats` to get zonal statistics for a raster and vector geometry:"
    ]
   },
   {
@@ -239,7 +251,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rasterstats.gen_zonal_stats?"
+    "help(rasterstats.gen_zonal_stats)"
    ]
   },
   {
@@ -247,9 +259,9 @@
    "id": "5a84498e",
    "metadata": {},
    "source": [
-    "In the panel that opens up below, you should see the usage for `rasterstats.gen_zonal_stats()`, which is the same as the usage for `rasterstats.zonal_stats()`. Have a look at the documentation - we'll go over an example below, but there are many more useful features that we won't go into in the tutorial.\n",
+    "In the output of the cell above, you should see the usage for `rasterstats.gen_zonal_stats()`, which is the same as the usage for `rasterstats.zonal_stats()`. Have a look at the documentation - we'll go over an example below, but there are many more useful features that we won't go into in the tutorial.\n",
     "\n",
-    "In the following cell, we use [`rasterstats.zonal_stats()`](https://pythonhosted.org/rasterstats/manual.html#zonal-statistics) with our `counties` and `landcover` datasets to do the same exercise as above (counting unique pixel values).\n",
+    "In the following cell, we use `rasterstats.zonal_stats()` ([documentation](https://pythonhosted.org/rasterstats/manual.html#zonal-statistics)) with our `counties` and `landcover` datasets to do the same exercise as above (counting unique pixel values).\n",
     "\n",
     "Rather than counting the pixels in the entire raster, however, we want to count the number of pixels with each land cover value that fall within a specific area defined by each of the features in the  `counties` dataset:"
    ]
@@ -278,33 +290,11 @@
    "id": "subtle-balance",
    "metadata": {},
    "source": [
-    "## 3. The zip built-in\n",
+    "## the zip built-in\n",
     "\n",
-    "Now let's say that we want to create a __dict__ so that we can get the landcover statistics for each county, but without having to look up the county's index in the `counties` table. We could iterate over the `counties` __GeoDataFrame__ to do this:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1dae07c6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "county_dict = dict()\n",
-    "for ind, row in counties.iterrows():\n",
-    "    county_dict[row['CountyName'].title()] = county_stats[ind] # we're using str.title() because we're not shouting.\n",
+    "We introduced the `zip()` built-in function above, but it's worth discussing this powerful and useful function in a bit more detail. \n",
     "\n",
-    "print(county_dict['Tyrone']) # this should be the same as the output for the previous cell"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "060e1bbc",
-   "metadata": {},
-   "source": [
-    "In this section, we'll see another way that we can achieve the same thing, using the built-in __zip__ function ([documentation](https://docs.python.org/3.8/library/functions.html#zip)). \n",
-    "\n",
-    "In Python 3, __zip()__ returns an __iterator__ object that combines elements from each of the iterable objects passed as arguments:"
+    "In Python 3, `zip()` returns a **zip** object that combines elements from each of the iterable objects passed as arguments:"
    ]
   },
   {
@@ -325,7 +315,7 @@
    "id": "f01ff4ee",
    "metadata": {},
    "source": [
-    "To see the pairs of items, we can pass the output of __zip__ to __list__:"
+    "We have seen something similar with **iterator** objects before - for example, the output of `range()` is an **iterator**. As we have seen, we can *iterate* over the items of the **iterator** object, or we can use something like `list()` to convert the **iterator** into another type of object:"
    ]
   },
   {
@@ -343,7 +333,7 @@
    "id": "06857750",
    "metadata": {},
    "source": [
-    "We can also pass the output of __zip__ to __dict__, to create a __dict__ of __key__/__value__ pairs:"
+    "And, as we saw above, we can also pass the output of `zip()` to `dict()`, to create a **dict** of **key**/**value** pairs - this is an efficient way to create a **dict** object from two **list** objects of different items:"
    ]
   },
   {
@@ -361,7 +351,7 @@
    "id": "intermediate-saskatchewan",
    "metadata": {},
    "source": [
-    "One thing to keep in mind is that with `zip(x, y)`, each of the elements of `x` is paired with the corresponding element from `y`. If `x` and `y` are different lengths, `zip(x, y)` will only use up to the shorter of the two:"
+    "One thing to keep in mind, though, is that with `zip(x, y)`, each of the elements of `x` is paired with the corresponding element from `y`. If `x` and `y` are different lengths, `zip(x, y)` will only use up to the shorter of the two:"
    ]
   },
   {
@@ -381,7 +371,7 @@
    "id": "a378bb08",
    "metadata": {},
    "source": [
-    "As a final example, we can also use __zip__ to combine more than two iterables:"
+    "As a final example, we can also use `zip()` to combine more than two iterables - we're not limited to a single pair of iterables:"
    ]
   },
   {
@@ -403,9 +393,9 @@
    "id": "funded-locator",
    "metadata": {},
    "source": [
-    "Now, let's use __zip__ to create a __dict__ that returns the landcover stats for each county, given the county name.\n",
+    "Now, let's use `zip()` to create a **dict** that returns the landcover stats for each county, given the county name.\n",
     "\n",
-    "First, we can use a _list comprehension_ to get a list of the county names, formatted using `str.title()`:"
+    "First, we can use a *list comprehension* to get a list of the county names, formatted using `str.title()`:"
    ]
   },
   {
@@ -423,7 +413,7 @@
    "id": "personal-dynamics",
    "metadata": {},
    "source": [
-    "Now, we use __dict__ and __zip__ to create the same __dict__ object that we did before."
+    "Now, we use `dict()` and `zip()` to create the **dict** object of landcover stats by county:"
    ]
   },
   {
@@ -433,8 +423,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stats_dict = dict(zip(names, county_stats))\n",
-    "print(stats_dict['Tyrone']) # should be the same output as before"
+    "county_dict = dict(zip(names, county_stats))\n",
+    "print(county_dict['Tyrone']) # should be the same output as before"
    ]
   },
   {
@@ -442,7 +432,7 @@
    "id": "conceptual-multiple",
    "metadata": {},
    "source": [
-    "## 4. Handling Exceptions with try ... except\n",
+    "## handling Exceptions with try ... except\n",
     "\n",
     "Now, let's add information about the percent landcover to the `counties` table. We'll start by using creating a __dict__ that takes the full landcover class name, and shortens it so that it can be used as a column header:"
    ]
@@ -482,27 +472,58 @@
   },
   {
    "cell_type": "markdown",
-   "id": "median-mailman",
+   "id": "a2bfa704-83de-430a-8739-6ac5c4b3a1a3",
    "metadata": {},
    "source": [
-    "What happened? From the error message above, we can see that there is no entry for `Saltwater` in the data for this county (Tyrone). This means that when we try to use `Saltwater` as a __key__ in the `county_data` dictionary, it raises a __KeyError__.\n",
+    "What happened here? \n",
     "\n",
-    "The problem that we have here is that we don't necessarily have all landcover classes represented in every county - County Tyrone is an inland county, so it makes sense that it doesn't have any saltwater areas.\n",
+    "From the error message above, we can see that there is no entry for `Saltwater` in the data for this county (Tyrone): "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20b1b9b1-bae2-4131-9d2b-3bb2e6aa5c1d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(row['CountyName'].title()) # show the county name that caused the error\n",
+    "print('Saltwater' in county_dict[row['CountyName'].title()].keys()) # is Saltwater a valid key for this county?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d39ed73-622a-4d70-a3c2-7c8088e25d6a",
+   "metadata": {},
+   "source": [
+    "Because `Saltwater` is not in the list of **key** values for this **dict**, when we try to use `Saltwater` as a **key** in the `county_data` dictionary, it raises a **KeyError**. \n",
     "\n",
-    "We could insert an __if__/__else__ block to check that the landcover class is present in the __dict__ before trying to access it:\n",
+    "The problem that we have here is that we don't necessarily have all landcover classes represented in every county. We shouldn't expect to, either - County Tyrone is an inland county, so it makes sense that it wouldn't have any saltwater areas.\n",
     "\n",
-    "```python\n",
+    "One way to handle this could be to insert an **if**/**else** block to check that the landcover class is present in the **dict** before trying to access it. This would check whether the value of `name` is a **key** of `county_data` - if it isn't, then it will add a value of 0 to the table for that column:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7fb6cd18-f75b-4261-98a5-0c886ba60c0a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "for ind, row in counties.iterrows(): # use iterrows to iterate over the rows of the table\n",
     "    county_data = county_dict[row['CountyName'].title()] # get the landcover data for this county\n",
     "    for name in landcover_names.values(): # iterate over each of the landcover class names\n",
     "        if name in county_data.keys(): # check that name is a key of county_data\n",
     "            counties.loc[ind, short_dict[name]] = county_data[name] # add the landcover count to a new column\n",
     "        else:\n",
-    "            counties.loc[ind, short_dict[name]] = 0 # if name is not present, value should be 0.\n",
-    "```\n",
-    "\n",
-    "This would check that __name__ is a __key__ of `county_data` - if it isn't, then it will add a value of 0 to the table for that column.\n",
-    "\n",
+    "            counties.loc[ind, short_dict[name]] = 0 # if name is not present, value should be 0."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "median-mailman",
+   "metadata": {},
+   "source": [
     "Another option is to use a [`try` ... `except`](https://realpython.com/python-exceptions/#the-try-and-except-block-handling-exceptions) block to \"catch\" and handle an exception:\n",
     "\n",
     "```python\n",
@@ -530,7 +551,7 @@
     "    for name in landcover_names.values(): # iterate over each of the landcover class names\n",
     "        try:\n",
     "            counties.loc[ind, short_dict[name]] = county_data[name] # add the landcover count to a new column\n",
-    "        except KeyError:\n",
+    "        except KeyError: # we can ignore KeyErrors, because this just means the landcover class has a value of 0\n",
     "            counties.loc[ind, short_dict[name]] = 0 # if name is not present, value should be 0.\n",
     "\n",
     "counties # just to show the table in the output below"
@@ -565,9 +586,11 @@
    "source": [
     "In the above, you can see that we've _indexed_ the table using the list of column names `short_name`, which ensures that we only select the columns we're interested in.\n",
     "\n",
-    "<span style=\"color:#009fdf;font-size:1.1em;font-weight:bold\">Looking at the table above, what landcover class dominates each county?</span>\n",
+    "<span style=\"color:#009fdf;font-size:1.1em;font-weight:bold\">Looking at the table above, what landcover class dominates each county? Does this make sense, given what you know about Northern Ireland?</span>\n",
     "\n",
-    "As a final exercise, modify the cell below so that each cell represents the total area (in square km) covered by each landcover class, rather than the number of pixels or the percent area of each county. As a small hint, you should only need to change a single line:"
+    "As a final exercise, modify the cell below so that each cell represents the total area (in square km) covered by each landcover class, rather than the number of pixels or the percent area of each county. \n",
+    "\n",
+    "As a small hint, you should only need to change a single line:"
    ]
   },
   {
@@ -593,8 +616,8 @@
    "id": "secondary-appeal",
    "metadata": {},
    "source": [
-    "## 5. Rasterizing vector data using rasterio\n",
-    "`rasterstats` provides a nice tool for quickly and easily extracting zonal statistics from a raster using vector data. Sometimes, though, we might want to _rasterize_ our vector data - for example, in order to mask our raster data, or to be able to select pixels. To do this, we can use the [`rasterio.features`](https://rasterio.readthedocs.io/en/latest/api/rasterio.features.html) module:"
+    "## rasterizing vector data using rasterio\n",
+    "`rasterstats` provides a nice tool for quickly and easily extracting zonal statistics from a raster using vector data. Sometimes, though, we might want to *rasterize* our vector data - for example, in order to mask our raster data, or to be able to select pixels. To do this, we can use the `rasterio.features` module ([documentation](https://rasterio.readthedocs.io/en/latest/api/rasterio.features.html)):"
    ]
   },
   {
@@ -609,47 +632,28 @@
   },
   {
    "cell_type": "markdown",
+   "id": "94a6847a-d78f-4e64-8e25-07d934feb657",
+   "metadata": {},
+   "source": [
+    "`rasterio.features`has a number of different methods, but the one we are interested in here is `rasterize()` ([documentation](https://rasterio.readthedocs.io/en/latest/api/rasterio.features.html#rasterio.features.rasterize)):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fa65ede8-9cd2-465b-8041-f83e63e893da",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "help(rio.features.rasterize)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "employed-prisoner",
    "metadata": {},
    "source": [
-    "`rasterio.features`has a number of different methods, but the one we are interested in here is `rasterize()`:\n",
-    "\n",
-    "```\n",
-    "rio.features.rasterize(\n",
-    "    shapes,\n",
-    "    out_shape=None,\n",
-    "    fill=0,\n",
-    "    out=None,\n",
-    "    transform=Affine(1.0, 0.0, 0.0,\n",
-    "       0.0, 1.0, 0.0),\n",
-    "    all_touched=False,\n",
-    "    merge_alg=<MergeAlg.replace: 'REPLACE'>,\n",
-    "    default_value=1,\n",
-    "    dtype=None,\n",
-    ")\n",
-    "Docstring:\n",
-    "Return an image array with input geometries burned in.\n",
-    "\n",
-    "Warnings will be raised for any invalid or empty geometries, and\n",
-    "an exception will be raised if there are no valid shapes\n",
-    "to rasterize.\n",
-    "\n",
-    "Parameters\n",
-    "----------\n",
-    "shapes : iterable of (`geometry`, `value`) pairs or iterable over\n",
-    "    geometries. The `geometry` can either be an object that\n",
-    "    implements the geo interface or GeoJSON-like object. If no\n",
-    "    `value` is provided the `default_value` will be used. If `value`\n",
-    "    is `None` the `fill` value will be used.\n",
-    "out_shape : tuple or list with 2 integers\n",
-    "    Shape of output numpy ndarray.\n",
-    "fill : int or float, optional\n",
-    "    Used as fill value for all areas not covered by input\n",
-    "    geometries.\n",
-    "...\n",
-    "```\n",
-    "\n",
-    "Here, we pass an __iterable__ (__list__, __tuple__, __array__, etc.) that contains (__geometry__, __value__) pairs. __value__ determines the pixel values in the output raster that the __geometry__ overlaps. If we don't provide a __value__, it takes the `default_value` or the `fill` value.\n",
+    "Here, we pass an **iterable** object (**list**, **tuple**, **array**, etc.) that contains (`geometry`, `value`) pairs. `value` determines the pixel values in the output raster that the `geometry` overlaps. If we don't provide a `value`, it takes the `default_value` or the `fill` value.\n",
     "\n",
     "So, to create a rasterized version of our county outlines, we could do the following:"
    ]
@@ -679,7 +683,7 @@
     "\n",
     "Since we want to use this rasterized output with our `landcover`, we use the `shape` of the `landcover` raster, as well as its `transform` (`affine_tfm`) - that way, the outputs will line up as we expect. \n",
     "\n",
-    "Run the cell below to see what the output looks like:"
+    "The cell below will display the `county_mask` raster in a `matplotlib` **Figure**:"
    ]
   },
   {
@@ -690,7 +694,8 @@
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(1, 1)\n",
-    "ax.imshow(county_mask) # visualize the rasterized output"
+    "im = ax.imshow(county_mask) # visualize the rasterized output\n",
+    "fig.colorbar(im) # show a colorbar"
    ]
   },
   {
@@ -698,10 +703,10 @@
    "id": "variable-brooks",
    "metadata": {},
    "source": [
-    "As you can see, this provides us with an __array__ whose values correspond to the `COUNTY_ID` of the county feature at that location (check the `counties` __GeoDataFrame__ again to see which county corresponds to which ID). In the next section, we'll see how we can use arrays like this to investigate our data further.\n",
+    "As you can see, this provides us with an **array** whose values correspond to the `COUNTY_ID` of the county feature at that location (check the `counties` **GeoDataFrame** again to see which county corresponds to which ID). In the next section, we'll see how we can use arrays like this to investigate our data further.\n",
     "\n",
-    "## 6. Masking and indexing rasters\n",
-    "So far, we've seen how we can index an array (or a list, a tuple, ...) using simple indexing (e.g., `myList[0]`) or _slicing_ (e.g., `myList[2:4]`). `numpy` arrays, however, can [actually be indexed](https://numpy.org/doc/stable/reference/arrays.indexing.html) using other arrays of type `bool` (the elements of the array are boolean (`True`/`False`) values). \n",
+    "## masking and indexing rasters\n",
+    "So far, we've seen how we can index an array (or a list, a tuple, ...) using simple indexing (e.g., `myList[0]`) or _slicing_ (e.g., `myList[2:4]`). `numpy` arrays, however, can [actually be indexed](https://numpy.org/doc/stable/reference/arrays.indexing.html) using other arrays of type `bool` (the elements of the array are boolean (`True`/`False`) values) - similar to how we have used conditional statements to select rows from a **GeoDataFrame**. \n",
     "\n",
     "In this section, we'll see how we can use this, along with our rasterized vectors, to select and investigate values from a raster using boolean indexing.\n",
     "\n",
@@ -809,9 +814,9 @@
    "id": "corrected-awareness",
    "metadata": {},
    "source": [
-    "Now, we have two different arrays, `broad_els` and `conif_els`, each corresponding to the DEM pixel values of each landcover type. We can plot a histogram of these arrays using [`plt.hist()`](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.hist.html), but this will only tell us the number of pixels - to work with areas, remember that we have to convert the pixel counts into areas by multiplying with the pixel area (100 m x 100 m).\n",
+    "Now, we have two different arrays, `broad_els` and `conif_els`, each corresponding to the DEM pixel values of each landcover type. We can plot a histogram of these arrays using `plt.hist()` ([documentation](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.hist.html)), but this will only tell us the number of pixels - to work with areas, remember that we have to convert the pixel counts into areas by multiplying with the pixel area (here, 100 m x 100 m).\n",
     "\n",
-    "First, though, we can use `numpy.histogram()`, along with an array representing our elevation bins, to produce a count of the number of pixels with an elevation that falls within each bin. Let's try elevations ranging from 0 to 600 meters, with a spacing of 5 meters:"
+    "First, though, we can use `numpy.histogram()` ([documentation](https://numpy.org/doc/stable/reference/generated/numpy.histogram.html)), along with an **array** representing our elevation bins, to produce a count of the number of pixels with an elevation that falls within each bin. We'll use `numpy.arange()` ([documentation](https://numpy.org/doc/stable/reference/generated/numpy.arange.html)) to generate an **array** of elevation bins ranging from 0 to 600 meters, spaced by 5 meters:"
    ]
   },
   {
@@ -835,7 +840,7 @@
    "id": "signed-hostel",
    "metadata": {},
    "source": [
-    "Finally, we can plot the area-elevation distribution for each land cover type using [`matplotlib.pyplot.bar()`](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.bar.html):"
+    "Finally, we can plot the area-elevation distribution for each land cover type using `plt.bar()` ([documentation](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.bar.html)):"
    ]
   },
   {
@@ -866,7 +871,7 @@
    "source": [
     "From this, we can clearly see that Conifer woodlands tend to be found at much higher elevations than Broadleaf woodlands, and at a much larger range of elevations (0-500 m, compared to 0-250 m or so). \n",
     "\n",
-    "With these samples (`broad_els`, `conif_els`), we can also calculate statistics for each of these samples using `numpy` functions such as `np.mean()`, `np.median()`, `np.std()`, and so on:"
+    "With these samples (`broad_els`, `conif_els`), we can also calculate statistics for each of these samples using `numpy` functions such as `np.mean()` ([documentation](https://numpy.org/doc/stable/reference/generated/numpy.mean.html)), `np.median()` ([documentation](https://numpy.org/doc/stable/reference/generated/numpy.median.html)), `np.std()` ([documentation](https://numpy.org/doc/stable/reference/generated/numpy.std.html)), and so on:"
    ]
   },
   {
@@ -885,7 +890,9 @@
    "id": "42a73bf9",
    "metadata": {},
    "source": [
-    "<span style=\"color:#009fdf;font-size:1.1em;font-weight:bold\">Of the 10 different landcover types shown here, which one has the highest mean elevation? What about the largest spread in elevation values?</span>"
+    "<span style=\"color:#009fdf;font-size:1.1em;font-weight:bold\">Of the 10 different landcover types shown here, which one has the highest mean elevation? What about the largest spread in elevation values?</span>\n",
+    "\n",
+    "Starting from the initial code in the cell below, create a **DataFrame** of descriptive statistics of the elevation for each landcover type, which will help you answer this question."
    ]
   },
   {
@@ -896,7 +903,7 @@
    "outputs": [],
    "source": [
     "# create a new pandas DataFrame with 6 columns\n",
-    "landcover_els = pd.DataFrame(columns=['name', 'mean', 'median', 'std. dev', 'max', 'min']) \n",
+    "landcover_els = pd.DataFrame(columns=['name', 'mean', 'median', 'std. dev', 'max', 'min', 'range']) \n",
     "\n",
     "landcover_els['name'] = short_names # add the short names to the 'name' column\n",
     "\n",
@@ -911,7 +918,7 @@
    "source": [
     "## Next steps\n",
     "\n",
-    "That's all for this practical. In lieu of an an additional exercise this week, spend some time working on your project - are there concepts or examples from this practical that you can incorporate into your project?\n",
+    "That's all for this practical. In lieu of an additional exercise this week, spend some time working on your project - are there concepts or examples from this practical that you can incorporate into your project?\n",
     "\n",
     "### Footnotes\n",
     "[<sup id=\"fn1\">1</sup>](#fn1-back)Rowland, C.S.; Morton, R.D.; Carrasco, L.; McShane, G.; O'Neil, A.W.; Wood, C.M. (2017). Land Cover Map 2015 (25m raster, N. Ireland). NERC Environmental Information Data Centre. [doi:10.5285/47f053a0-e34f-4534-a843-76f0a0998a2f](https://doi.org/10.5285/47f053a0-e34f-4534-a843-76f0a0998a2f)</span>"
@@ -934,7 +941,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.12.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This update makes the following changes:

- additional explanations and links to documentation for functions, methods, and classes
- renames `Practical5.ipynb` as `RasterStats.ipynb`